### PR TITLE
StrParam support / Call Discard / ***ActorProperty

### DIFF
--- a/acsutil.py
+++ b/acsutil.py
@@ -1411,6 +1411,8 @@ class Call(Instruction):
         Instruction.parse(self, p)
 
     def parse_block(self, p, block):
+        if(not(self.wantresult)):
+            block.put(self)
         Instruction.parse_block(self, p, block)
 
     def disassemble(self):
@@ -1691,7 +1693,7 @@ def genpcodes():
 
     # Functions
     apcode('CALL', 'V', Call, True)
-    apcode('CALLDISCARD', 'V', Call, True)
+    apcode('CALLDISCARD', 'V', Call, False)
     pcode('RETURNVOID', ReturnVoid, 'return')
     pcode('RETURNVAL', Return, 'return')
 

--- a/acsutil.py
+++ b/acsutil.py
@@ -1694,6 +1694,7 @@ def genpcodes():
     # Functions
     apcode('CALL', 'V', Call, True)
     apcode('CALLDISCARD', 'V', Call, False)
+    apcode('CALLFUNC', 'V', Call, True)
     pcode('RETURNVOID', ReturnVoid, 'return')
     pcode('RETURNVAL', Return, 'return')
 
@@ -1937,6 +1938,7 @@ def genpcodes():
     builtin_stack('ThingCountName', 2, False, ConvStrings(0))
     builtin_stack('SpawnSpotFacing', 3, False, ConvStrings(0))
     builtin_stack('PlayerClass', 1, False)
+    builtin_stack('StrParam', 1, False)
 
     pcode('STARTTRANSLATION', CreateTranslation)
     pcode('TRANSLATIONRANGE1', TranslationRange, 4)
@@ -2085,7 +2087,7 @@ pcode_names = [
     'THINGCOUNTSECTOR', 'THINGCOUNTNAMESECTOR',
     'CHECKPLAYERCAMERA', 'MORPHACTOR', 'UNMORPHACTOR',
     'GETPLAYERINPUT', 'CLASSIFYACTOR', 'PRINTBINARY',
-    'PRINTHEX']
+    'PRINTHEX','CALLFUNC','STRPARAM']
 
 linespecials = [
     None, None, 'Polyobj_RotateLeft',

--- a/acsutil.py
+++ b/acsutil.py
@@ -1455,25 +1455,25 @@ class ConvStrings(ArgumentInterpreter):
 
 class ActorPropArgs(ArgumentInterpreter):
     def convert(self, p, args):
-        val = args[0]
+        val1 = args[0]
         valstring = False
-        if isinstance(val, Literal):
+        if isinstance(val1, Literal):
             try:
-                nm, valstring = aprop_names[val.val]
-                val = ConstantReference(nm, val.val)
+                name, valstring = aprop_names[val1.val]
+                val1 = ConstantReference(name, val1.val)
             except Exception:
                 pass
 
-        yield val
 
-        val = args[1]
+        val2 = args[1]
         if valstring:
-            val = val.lookupstring(val)
+            val2 = val2.lookupstring(val2)
 
-        yield val
+        yield val2
+        yield val1
 
         for i in args[2:]:
-            yield val
+            yield i
 
 
 class BuiltinCall(Instruction):

--- a/acsutil.py
+++ b/acsutil.py
@@ -2185,12 +2185,21 @@ script_types = [
     "RETURN"
 ]
 
+#Actors properties
+#References:
+# - for the index order: https://github.com/rheit/zdoom/blob/master/src/p_acs.cpp#L3615
+# - for property type : https://zdoom.org/wiki/CheckActorProperty
 aprop_names = [
     ('APROP_Health', False),
     ('APROP_Speed', False),
     ('APROP_Damage', False),
     ('APROP_Alpha', False),
     ('APROP_RenderStyle', False),
+    ('APROP_SeeSound', True),
+    ('APROP_AttackSound', True),
+    ('APROP_PainSound', True),
+    ('APROP_DeathSound', True),
+    ('APROP_ActiveSound', True),
     ('APROP_Ambush', False),
     ('APROP_Invulnerable', False),
     ('APROP_JumpZ', False),
@@ -2199,11 +2208,36 @@ aprop_names = [
     ('APROP_Gravity', False),
     ('APROP_Friendly', False),
     ('APROP_SpawnHealth', False),
-    ('APROP_SeeSound', True),
-    ('APROP_AttackSound', True),
-    ('APROP_PainSound', True),
-    ('APROP_DeathSound', True),
-    ('APROP_ActiveSound', True),
+    ('APROP_Dropped', False),
+    ('APROP_Notarget', False),
+    ('APROP_Species', True),
+    ('APROP_NameTag', True),
+    ('APROP_Score', False),
+    ('APROP_Notrigger', False),
+    ('APROP_DamageFactor', False),
+    ('APROP_MasterTID', False),
+    ('APROP_TargetTID', False),
+    ('APROP_TracerTID', False),
+    ('APROP_WaterLevel', False),
+    ('APROP_ScaleX', False),
+    ('APROP_ScaleY', False),
+    ('APROP_Dormant', False),
+    ('APROP_Mass', False),
+    ('APROP_Accuracy', False),
+    ('APROP_Dormant', False),
+    ('APROP_Stamina', False),
+    ('APROP_Height', False),
+    ('APROP_Radius', False),
+    ('APROP_ReactionTime', False),
+    ('APROP_MeleeRange', False),
+    ('APROP_ViewHeight', False),
+    ('APROP_AttackZOffset', False),
+    ('APROP_StencilColor', False),
+    ('APROP_Friction', False),
+    ('APROP_DamageMultiplier', False),
+    ('APROP_MaxStepHeight', False),
+    ('APROP_MaxDropOffHeight', False),
+    ('APROP_DamageType', True),
 ]
 
 pcode_index = {}


### PR DESCRIPTION
## StrParam

The not so perfect implementation.

Source code like this :
```js
StrParam(s:local1, d:local2);
```
Will look like this :
```js
StrParam(UnknownPrint(s:local1, d:local2; ));
```

I left the `UnknownPrint` because it is currently used to mark print instructions that are not a straight `Print()` call (string buffer related operations). By hiding it, their could be other cases where nothing is display.
Now the pcode 352 is properly mapped to StrParam. While it is not 1 to 1 matching the original source code, it is clear when reading the decompiled code.

## Call Discard (Follow up to #5)

The call need to be explicitly display when they are not nested inside another expression. Call inside assignment block or a built-in call were already managed by their parent expression.

## SetActorProperty / GetActorProperty

I didn't realise it initially but both method had the wrong order of parameters. This was because I was mostly doing test with a script were only the property health (0) and actor 0 was used.
The value passed to the SetActorProperty (3rd arg) was a copy of the second argument. Clearly a variable typo that was overlooked.

I have also add recent actor properties.
